### PR TITLE
Compose palette

### DIFF
--- a/src/constants/PALETTE.ts
+++ b/src/constants/PALETTE.ts
@@ -1,0 +1,25 @@
+export const MAIN = {
+  primary: "#127CEA",
+  secondary: "#558CC7",
+  tertiary: "#061D38",
+} as const;
+
+export const GRAYSCALE = {
+  white: "#FFFFFF",
+  gray50: "#F0F4F8",
+  gray100: "#E2E6EA",
+  gray200: "#C9CDD1",
+  gray300: "#B0B4B8",
+  gray400: "#979B9F",
+  gray500: "#7E8286",
+  gray600: "#65696D",
+  gray700: "#4C5054",
+  gray800: "#33373B",
+  gray900: "#1A1E22",
+  black: "#000000",
+} as const;
+
+export const SEMANTIC = {
+  error: "#E91051",
+  warning: "#FF9500",
+} as const;

--- a/src/pages/PalettePage.tsx
+++ b/src/pages/PalettePage.tsx
@@ -1,7 +1,42 @@
+import { Box, Stack, styled } from "@mui/material";
 import Page from "../components/Page";
+import { GRAYSCALE, MAIN, SEMANTIC } from "../constants/PALETTE";
 
 const PalettePage = () => {
-  return <Page>Palette</Page>;
+  return (
+    <Page>
+      <Stack direction="row" gap={2}>
+        <PaletteBox bgcolor={MAIN.primary} />
+        <PaletteBox bgcolor={MAIN.secondary} />
+      </Stack>
+      <Stack direction="row" gap={2}>
+        <PaletteBox bgcolor={GRAYSCALE.white} />
+        <PaletteBox bgcolor={GRAYSCALE.gray50} />
+        <PaletteBox bgcolor={GRAYSCALE.gray100} />
+        <PaletteBox bgcolor={GRAYSCALE.gray200} />
+        <PaletteBox bgcolor={GRAYSCALE.gray300} />
+        <PaletteBox bgcolor={GRAYSCALE.gray400} />
+        <PaletteBox bgcolor={GRAYSCALE.gray500} />
+        <PaletteBox bgcolor={GRAYSCALE.gray600} />
+        <PaletteBox bgcolor={GRAYSCALE.gray700} />
+        <PaletteBox bgcolor={GRAYSCALE.gray800} />
+        <PaletteBox bgcolor={GRAYSCALE.gray900} />
+        <PaletteBox bgcolor={GRAYSCALE.black} />
+      </Stack>
+      <Stack direction="row" gap={2}>
+        <PaletteBox bgcolor={SEMANTIC.error} />
+        <PaletteBox bgcolor={SEMANTIC.warning} />
+      </Stack>
+    </Page>
+  );
 };
+
+const PaletteBox = styled(Box)`
+  width: 50px;
+  height: 50px;
+
+  border-radius: 10px;
+  border: 2px solid ${({ theme }) => theme.palette.grayscale.black};
+`;
 
 export default PalettePage;

--- a/src/themes/palette-theme.ts
+++ b/src/themes/palette-theme.ts
@@ -1,7 +1,31 @@
 import { createTheme } from "@mui/material";
+import { GRAYSCALE, MAIN, SEMANTIC } from "../constants/PALETTE";
 
 const paletteTheme = createTheme({
-  palette: {},
+  palette: {
+    main: {
+      primary: MAIN.primary,
+      secondary: MAIN.secondary,
+    },
+    grayscale: {
+      white: GRAYSCALE.white,
+      gray50: GRAYSCALE.gray50,
+      gray100: GRAYSCALE.gray100,
+      gray200: GRAYSCALE.gray200,
+      gray300: GRAYSCALE.gray300,
+      gray400: GRAYSCALE.gray400,
+      gray500: GRAYSCALE.gray500,
+      gray600: GRAYSCALE.gray600,
+      gray700: GRAYSCALE.gray700,
+      gray800: GRAYSCALE.gray800,
+      gray900: GRAYSCALE.gray900,
+      black: GRAYSCALE.black,
+    },
+    semantic: {
+      error: SEMANTIC.error,
+      warning: SEMANTIC.warning,
+    },
+  },
 });
 
 export default paletteTheme;

--- a/src/types/palette.d.ts
+++ b/src/types/palette.d.ts
@@ -1,0 +1,40 @@
+import "@mui/material/styles";
+
+declare module "@mui/material/styles" {
+  interface Palette {
+    main: MainPalette;
+    grayscale: GrayscalePalette;
+    semantic: SemanticPalette;
+  }
+
+  interface PaletteOptions {
+    main?: MainPalette;
+    grayscale?: GrayscalePalette;
+    semantic?: SemanticPalette;
+  }
+}
+
+type MainPalette = {
+  primary: string;
+  secondary: string;
+};
+
+type GrayscalePalette = {
+  white: string;
+  gray50: string;
+  gray100: string;
+  gray200: string;
+  gray300: string;
+  gray400: string;
+  gray500: string;
+  gray600: string;
+  gray700: string;
+  gray800: string;
+  gray900: string;
+  black: string;
+};
+
+type SemanticPalette = {
+  error: string;
+  warning: string;
+};


### PR DESCRIPTION
# Pull Request

### Description

This pull request introduces a centralized color palette system and integrates it into the application's theme and UI. The changes define new color constants, update the theme to use these constants, and visually display the palette on the `PalettePage`.

### Changes

**Palette system introduction and integration:**

- Defined centralized color constants for main, grayscale, and semantic colors in `PALETTE.ts`, providing a single source of truth for color values.
- Updated the MUI theme in `palette-theme.ts` to expose the new color groups (`main`, `grayscale`, and `semantic`) via the `palette` object, making them accessible throughout the application.

**UI updates:**

- Refactored `PalettePage.tsx` to display the defined color palette using the new constants, and added a reusable `PaletteBox` component for visual consistency.