### PR TITLE
Publish Switch Component

### DIFF
--- a/src/themes/switch-theme.ts
+++ b/src/themes/switch-theme.ts
@@ -2,7 +2,26 @@ import { createTheme } from "@mui/material";
 
 const switchTheme = createTheme({
   components: {
-    MuiSwitch: {},
+    MuiSwitch: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          padding: 0,
+          borderStyle: "solid",
+          borderWidth: "1px",
+          borderColor: theme.palette.grayscale.gray700,
+          borderImage: "none",
+          borderRadius: "50px",
+        }),
+        track: ({ theme }) => ({
+          backgroundColor: theme.palette.grayscale.white,
+        }),
+        switchBase: ({ theme }) => ({
+          "&.Mui-checked + .MuiSwitch-track": {
+            backgroundColor: theme.palette.main.primary,
+          },
+        }),
+      },
+    },
   },
 });
 

--- a/src/themes/switch-theme.ts
+++ b/src/themes/switch-theme.ts
@@ -12,14 +12,29 @@ const switchTheme = createTheme({
           borderImage: "none",
           borderRadius: "50px",
         }),
-        track: ({ theme }) => ({
-          backgroundColor: theme.palette.grayscale.white,
+        track: ({ theme, ownerState }) => ({
+          backgroundColor: ownerState.disabled
+            ? theme.palette.grayscale.gray900
+            : theme.palette.grayscale.white,
         }),
         switchBase: ({ theme }) => ({
           "&.Mui-checked + .MuiSwitch-track": {
             backgroundColor: theme.palette.main.primary,
           },
+          "&.Mui-checked.Mui-disabled + .MuiSwitch-track": {
+            backgroundColor: theme.palette.grayscale.gray900,
+          },
+          "&.Mui-checked .MuiSwitch-thumb": {
+            backgroundColor: theme.palette.main.secondary,
+          },
+          "&.Mui-checked.Mui-disabled .MuiSwitch-thumb": {
+            backgroundColor: theme.palette.grayscale.gray400,
+          },
         }),
+        input: {
+          left: "unset",
+          top: "unset",
+        },
       },
     },
   },


### PR DESCRIPTION
This pull request updates the styling for the `MuiSwitch` component in the `switchTheme` theme. The changes introduce custom style overrides to improve the appearance and behavior of the switch, particularly regarding its borders, track, and thumb colors in various states (checked, disabled, etc.).

Styling updates for `MuiSwitch`:

* Added a custom border, padding, and border radius to the switch root for a more defined appearance.
* Customized the switch track's background color to respond to the disabled state using the grayscale palette.
* Enhanced the switch base to change the track and thumb colors based on checked and disabled states, utilizing the theme's primary, secondary, and grayscale colors.
* Adjusted the input positioning for better alignment.